### PR TITLE
Add extended balances stats with zero balance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ found [here](https://github.com/gcarq/rusty-blockparser/tree/master/src/callback
 
 #### Extract Balances of all known addresses
 
-The command `balances` extracts the balance of all known addresses and dumps it to a csv file called `balances.csv` with
-the following format:
+The command `balances` extracts balance information for all known addresses and dumps it to a csv file called `balances.csv`.
+Use the optional flag `--keep-zero-balances` to keep addresses with a final balance of zero in the output.
+The csv file is in the following format:
 
 ```
-balances.csv: address ; balance
+balances.csv: address ; balance ; pubkey ; total sent ; total received ; first spent time ; last spent time ; first received time ; last received time
 ```
 
 #### Extract all UTXOs along with their corresponding address balances

--- a/src/callbacks/balances.rs
+++ b/src/callbacks/balances.rs
@@ -5,17 +5,38 @@ use std::path::PathBuf;
 
 use clap::{Arg, ArgMatches, Command};
 
+use crate::blockchain::proto::tx::{TxOutpoint};
+use crate::blockchain::proto::script::ScriptPattern;
+
 use crate::blockchain::proto::block::Block;
 use crate::callbacks::{Callback, common};
 use crate::common::Result;
+use crate::common::utils;
 
-/// Dumps all addresses with non-zero balance in a csv file
+/// Holds statistics for a single address
+#[derive(Default)]
+struct AddressStats {
+    balance: u64,
+    total_sent: u64,
+    total_received: u64,
+    first_spent_time: Option<u32>,
+    last_spent_time: Option<u32>,
+    first_received_time: Option<u32>,
+    last_received_time: Option<u32>,
+    pubkey: Option<String>,
+}
+
+/// Dumps all addresses with their balance information in a csv file
 pub struct Balances {
     dump_folder: PathBuf,
     writer: BufWriter<File>,
 
     // key: txid + index
     unspents: HashMap<Vec<u8>, common::UnspentValue>,
+
+    stats: HashMap<String, AddressStats>,
+
+    keep_zero_balances: bool,
 
     start_height: u64,
     end_height: u64,
@@ -42,6 +63,12 @@ impl Callback for Balances {
                     .index(1)
                     .required(true),
             )
+            .arg(
+                Arg::new("keep-zero-balances")
+                    .long("keep-zero-balances")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Keep addresses with zero balance in output"),
+            )
     }
 
     fn new(matches: &ArgMatches) -> Result<Self>
@@ -49,10 +76,13 @@ impl Callback for Balances {
         Self: Sized,
     {
         let dump_folder = &PathBuf::from(matches.get_one::<String>("dump-folder").unwrap());
+        let keep_zero = matches.get_flag("keep-zero-balances");
         let cb = Balances {
             dump_folder: PathBuf::from(dump_folder),
             writer: Balances::create_writer(4000000, dump_folder.join("balances.csv.tmp"))?,
             unspents: HashMap::with_capacity(10000000),
+            stats: HashMap::new(),
+            keep_zero_balances: keep_zero,
             start_height: 0,
             end_height: 0,
         };
@@ -74,9 +104,57 @@ impl Callback for Balances {
     ///   * output_val
     ///   * address
     fn on_block(&mut self, block: &Block, block_height: u64) -> Result<()> {
+        let timestamp = block.header.timestamp;
         for tx in &block.txs {
-            common::remove_unspents(tx, &mut self.unspents);
-            common::insert_unspents(tx, block_height, &mut self.unspents);
+            // process inputs
+            for input in &tx.value.inputs {
+                let key = input.outpoint.to_bytes();
+                if let Some(unspent) = self.unspents.remove(&key) {
+                    let stats = self
+                        .stats
+                        .entry(unspent.address.clone())
+                        .or_default();
+                    stats.balance = stats.balance.saturating_sub(unspent.value);
+                    stats.total_sent += unspent.value;
+                    if stats.first_spent_time.is_none() {
+                        stats.first_spent_time = Some(timestamp);
+                    }
+                    stats.last_spent_time = Some(timestamp);
+
+                    if stats.pubkey.is_none() {
+                        if let Some(pk) = extract_pubkey_from_script_sig(&input.script_sig) {
+                            stats.pubkey = Some(pk);
+                        }
+                    }
+                }
+            }
+
+            // process outputs
+            for (i, output) in tx.value.outputs.iter().enumerate() {
+                if let Some(address) = &output.script.address {
+                    let key = TxOutpoint::new(tx.hash, i as u32).to_bytes();
+                    let unspent = common::UnspentValue {
+                        block_height,
+                        value: output.out.value,
+                        address: address.clone(),
+                    };
+                    self.unspents.insert(key, unspent);
+
+                    let stats = self.stats.entry(address.clone()).or_default();
+                    stats.balance += output.out.value;
+                    stats.total_received += output.out.value;
+                    if stats.first_received_time.is_none() {
+                        stats.first_received_time = Some(timestamp);
+                    }
+                    stats.last_received_time = Some(timestamp);
+
+                    if stats.pubkey.is_none() {
+                        if let Some(pk) = extract_pubkey_from_script_pubkey(&output.out.script_pubkey, &output.script.pattern) {
+                            stats.pubkey = Some(pk);
+                        }
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -84,19 +162,36 @@ impl Callback for Balances {
     fn on_complete(&mut self, block_height: u64) -> Result<()> {
         self.end_height = block_height;
 
-        self.writer
-            .write_all(format!("{};{}\n", "address", "balance").as_bytes())?;
+        self.writer.write_all(
+            b"address;balance;pubkey;total sent;total received;first spent time;last spent time;first received time;last received time\n",
+        )?;
 
-        // Collect balances for each address
-        let mut balances: HashMap<&str, u64> = HashMap::new();
-        for unspent in self.unspents.values() {
-            let entry = balances.entry(&unspent.address).or_insert(0);
-            *entry += unspent.value
-        }
+        for (address, stats) in &self.stats {
+            if !self.keep_zero_balances && stats.balance == 0 {
+                continue;
+            }
 
-        for (address, balance) in balances.iter() {
-            self.writer
-                .write_all(format!("{};{}\n", address, balance).as_bytes())?;
+            let line = format!(
+                "{};{};{};{};{};{};{};{};{}\n",
+                address,
+                stats.balance,
+                stats.pubkey.clone().unwrap_or_default(),
+                stats.total_sent,
+                stats.total_received,
+                stats
+                    .first_spent_time
+                    .map_or(String::new(), |v| v.to_string()),
+                stats
+                    .last_spent_time
+                    .map_or(String::new(), |v| v.to_string()),
+                stats
+                    .first_received_time
+                    .map_or(String::new(), |v| v.to_string()),
+                stats
+                    .last_received_time
+                    .map_or(String::new(), |v| v.to_string())
+            );
+            self.writer.write_all(line.as_bytes())?;
         }
 
         fs::rename(
@@ -108,7 +203,59 @@ impl Callback for Balances {
         )
         .expect("Unable to rename tmp file!");
 
-        info!(target: "callback", "Done.\nDumped {} addresses.", balances.len());
+        info!(
+            target: "callback",
+            "Done.\nDumped {} addresses.",
+            self.stats.len()
+        );
         Ok(())
+    }
+}
+
+fn extract_pubkey_from_script_sig(script: &[u8]) -> Option<String> {
+    let mut i = 0;
+    while i < script.len() {
+        let op = script[i] as usize;
+        if op >= 1 && op <= 75 {
+            if i + 1 + op > script.len() {
+                break;
+            }
+            let data = &script[i + 1..i + 1 + op];
+            if op == 33 || op == 65 {
+                return Some(utils::arr_to_hex(data));
+            }
+            i += 1 + op;
+        } else if op == 0x4c {
+            if i + 1 >= script.len() {
+                break;
+            }
+            let len = script[i + 1] as usize;
+            if i + 2 + len > script.len() {
+                break;
+            }
+            let data = &script[i + 2..i + 2 + len];
+            if len == 33 || len == 65 {
+                return Some(utils::arr_to_hex(data));
+            }
+            i += 2 + len;
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+fn extract_pubkey_from_script_pubkey(script: &[u8], pattern: &ScriptPattern) -> Option<String> {
+    match pattern {
+        ScriptPattern::Pay2PublicKey => {
+            if script.len() >= 35 && (script[0] == 33 || script[0] == 65) {
+                let len = script[0] as usize;
+                if script.len() >= len + 2 {
+                    return Some(utils::arr_to_hex(&script[1..1 + len]));
+                }
+            }
+            None
+        }
+        _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- enhance `balances` callback to track send/receive stats and timestamps
- add `--keep-zero-balances` flag
- update README for new CSV format

## Testing
- `cargo test` *(fails: failed to download crates)*